### PR TITLE
feat: implement smart deduplication and report rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -130,6 +131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +232,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,3 +287,9 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ clap = { version = "4.5.31", features = ["derive"] }
 once_cell = "1.20.3"
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1,10 +1,34 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use once_cell::sync::Lazy;
 use regex::Regex;
 
-use crate::model::{AnalysisReport, EvidenceLine, Finding, FindingKind, LogLine, Severity};
+use crate::model::{
+    AnalysisReport, EvidenceLine, Finding, FindingKind, LogLine, ParseWarning, ReportSummary,
+    Severity,
+};
 use crate::parser::ParsedLog;
 
+static PROCESS_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"Process:\s+([^,]+),\s+PID:\s+(\d+)").expect("valid process regex"));
+static HEX_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"0x[0-9a-fA-F]+|\b[0-9a-fA-F]{8,}\b").expect("valid hex regex"));
+static NUMBER_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\b\d+\b").expect("valid numeric regex"));
+static WHITESPACE_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\s+").expect("valid whitespace regex"));
+
 pub fn analyze(parsed: ParsedLog) -> AnalysisReport {
-    let lines = parsed.lines;
+    let findings = deduplicate_findings(collect_findings(&parsed.lines));
+    let summary = build_summary(&findings, &parsed.warnings);
+
+    AnalysisReport {
+        summary,
+        findings,
+        parse_warnings: parsed.warnings,
+    }
+}
+
+fn collect_findings(lines: &[LogLine]) -> Vec<Finding> {
     let mut findings = Vec::new();
     let mut last_consumed_line = 0usize;
 
@@ -14,7 +38,9 @@ pub fn analyze(parsed: ParsedLog) -> AnalysisReport {
         }
 
         if let Some(kind) = detect_anchor(line) {
-            let (line_start, line_end, evidence) = collect_evidence(&lines, index);
+            let (line_start, line_end, evidence) = collect_evidence(lines, index);
+            let exception = extract_exception(&evidence);
+            let root_cause = extract_root_cause(&evidence, line, exception.clone());
             let finding = Finding {
                 kind,
                 severity: severity_for(kind),
@@ -25,7 +51,10 @@ pub fn analyze(parsed: ParsedLog) -> AnalysisReport {
                 package: extract_package(&evidence),
                 process: extract_process(&evidence),
                 thread: extract_thread(&evidence),
-                exception: extract_exception(&evidence),
+                exception,
+                root_cause,
+                signature: String::new(),
+                occurrence_count: 1,
                 evidence,
             };
             last_consumed_line = finding.line_end;
@@ -33,10 +62,173 @@ pub fn analyze(parsed: ParsedLog) -> AnalysisReport {
         }
     }
 
-    AnalysisReport {
-        findings,
-        parse_warnings: parsed.warnings,
+    findings
+}
+
+fn deduplicate_findings(findings: Vec<Finding>) -> Vec<Finding> {
+    let mut grouped: BTreeMap<String, Finding> = BTreeMap::new();
+
+    for mut finding in findings {
+        let signature = build_signature(&finding);
+        finding.signature = signature.clone();
+
+        if let Some(existing) = grouped.get_mut(&signature) {
+            merge_findings(existing, finding);
+        } else {
+            grouped.insert(signature, finding);
+        }
     }
+
+    let mut deduped: Vec<Finding> = grouped.into_values().collect();
+    deduped.sort_by(|left, right| {
+        right
+            .severity
+            .cmp(&left.severity)
+            .then(right.occurrence_count.cmp(&left.occurrence_count))
+            .then(left.line_start.cmp(&right.line_start))
+    });
+
+    for finding in &mut deduped {
+        if finding.occurrence_count > 1 {
+            finding.rationale = format!(
+                "{} This normalized signature appeared {} times.",
+                finding.rationale, finding.occurrence_count
+            );
+        }
+    }
+
+    deduped
+}
+
+fn build_summary(findings: &[Finding], warnings: &[ParseWarning]) -> ReportSummary {
+    let mut root_cause_candidates = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    for finding in findings {
+        let candidate = finding
+            .root_cause
+            .as_deref()
+            .or(finding.exception.as_deref())
+            .unwrap_or(finding.title.as_str())
+            .to_string();
+
+        if seen.insert(candidate.clone()) {
+            root_cause_candidates.push(candidate);
+        }
+
+        if root_cause_candidates.len() == 3 {
+            break;
+        }
+    }
+
+    ReportSummary {
+        total_findings: findings.len(),
+        parse_warning_count: warnings.len(),
+        top_severity: findings.first().map(|finding| finding.severity),
+        root_cause_candidates,
+    }
+}
+
+fn merge_findings(existing: &mut Finding, incoming: Finding) {
+    existing.occurrence_count += 1;
+    existing.line_start = existing.line_start.min(incoming.line_start);
+    existing.line_end = existing.line_end.max(incoming.line_end);
+
+    if existing.root_cause.is_none() {
+        existing.root_cause = incoming.root_cause.clone();
+    }
+
+    if existing.exception.is_none() {
+        existing.exception = incoming.exception.clone();
+    }
+
+    if existing.process.is_none() {
+        existing.process = incoming.process.clone();
+    }
+
+    if existing.package.is_none() {
+        existing.package = incoming.package.clone();
+    }
+
+    if existing.thread.is_none() {
+        existing.thread = incoming.thread.clone();
+    }
+
+    let mut seen_messages: BTreeSet<String> = existing
+        .evidence
+        .iter()
+        .map(|line| normalized_message(&line.message))
+        .collect();
+    for line in incoming.evidence {
+        if existing.evidence.len() >= 12 {
+            break;
+        }
+
+        let normalized = normalized_message(&line.message);
+        if seen_messages.insert(normalized) {
+            existing.evidence.push(line);
+        }
+    }
+}
+
+fn build_signature(finding: &Finding) -> String {
+    let scope = finding
+        .package
+        .as_deref()
+        .or(finding.process.as_deref())
+        .unwrap_or("unknown-process");
+    let root_cause = finding
+        .root_cause
+        .as_deref()
+        .or(finding.exception.as_deref())
+        .unwrap_or(finding.title.as_str());
+    let frame = signature_frame(finding).unwrap_or_else(|| finding.title.clone());
+
+    format!(
+        "{}|{}|{}|{}",
+        kind_token(finding.kind),
+        normalized_message(scope),
+        normalized_message(root_cause),
+        normalized_message(&frame)
+    )
+}
+
+fn signature_frame(finding: &Finding) -> Option<String> {
+    let mut fallback = None;
+
+    for line in &finding.evidence {
+        let message = evidence_message(line).trim();
+        if message.starts_with("at ") {
+            if is_app_frame(message) {
+                return Some(message.to_string());
+            }
+
+            if fallback.is_none() {
+                fallback = Some(message.to_string());
+            }
+        } else if message.starts_with('#') && fallback.is_none() {
+            fallback = Some(message.to_string());
+        }
+    }
+
+    fallback
+}
+
+fn is_app_frame(frame: &str) -> bool {
+    !(frame.contains(" android.")
+        || frame.contains(" java.")
+        || frame.contains(" kotlin.")
+        || frame.contains(" androidx.")
+        || frame.contains(" com.android."))
+}
+
+fn normalized_message(value: &str) -> String {
+    let normalized = HEX_RE.replace_all(value, "<hex>");
+    let normalized = NUMBER_RE.replace_all(&normalized, "<num>");
+    WHITESPACE_RE
+        .replace_all(&normalized.to_lowercase(), " ")
+        .trim()
+        .to_string()
 }
 
 fn detect_anchor(line: &LogLine) -> Option<FindingKind> {
@@ -72,8 +264,21 @@ fn detect_anchor(line: &LogLine) -> Option<FindingKind> {
     None
 }
 
+fn is_primary_anchor(line: &LogLine) -> bool {
+    matches!(
+        detect_anchor(line),
+        Some(
+            FindingKind::FatalException
+                | FindingKind::Anr
+                | FindingKind::NativeCrash
+                | FindingKind::OutOfMemory
+                | FindingKind::JniError
+        )
+    )
+}
+
 fn collect_evidence(lines: &[LogLine], anchor_index: usize) -> (usize, usize, Vec<EvidenceLine>) {
-    let start = anchor_index.saturating_sub(2);
+    let start = anchor_index;
     let mut end = anchor_index;
     let mut evidence = Vec::new();
     let anchor = &lines[anchor_index];
@@ -85,6 +290,10 @@ fn collect_evidence(lines: &[LogLine], anchor_index: usize) -> (usize, usize, Ve
     }
 
     for (offset, line) in lines.iter().enumerate().skip(anchor_index + 1).take(24) {
+        if is_primary_anchor(line) {
+            break;
+        }
+
         if should_include_following_line(anchor, line, anchor_pid) {
             evidence.push(to_evidence(line));
             end = offset;
@@ -192,10 +401,6 @@ fn extract_thread(evidence: &[EvidenceLine]) -> Option<String> {
 }
 
 fn extract_process(evidence: &[EvidenceLine]) -> Option<String> {
-    static PROCESS_RE: once_cell::sync::Lazy<Regex> = once_cell::sync::Lazy::new(|| {
-        Regex::new(r"Process:\s+([^,]+),\s+PID:\s+(\d+)").expect("valid process regex")
-    });
-
     evidence.iter().find_map(|line| {
         PROCESS_RE.captures(evidence_message(line)).map(|captures| {
             format!(
@@ -237,6 +442,26 @@ fn extract_exception(evidence: &[EvidenceLine]) -> Option<String> {
     })
 }
 
+fn extract_root_cause(
+    evidence: &[EvidenceLine],
+    anchor: &LogLine,
+    exception: Option<String>,
+) -> Option<String> {
+    evidence
+        .iter()
+        .rev()
+        .find_map(|line| {
+            let message = evidence_message(line).trim();
+            if message.starts_with("Caused by:") {
+                Some(message.to_string())
+            } else {
+                None
+            }
+        })
+        .or(exception)
+        .or_else(|| Some(anchor.message.clone()))
+}
+
 fn to_evidence(line: &LogLine) -> EvidenceLine {
     EvidenceLine {
         line_number: line.line_number,
@@ -249,6 +474,17 @@ fn evidence_message(line: &EvidenceLine) -> &str {
         .split_once(": ")
         .map(|(_, message)| message)
         .unwrap_or(line.message.as_str())
+}
+
+fn kind_token(kind: FindingKind) -> &'static str {
+    match kind {
+        FindingKind::FatalException => "fatal_exception",
+        FindingKind::Anr => "anr",
+        FindingKind::NativeCrash => "native_crash",
+        FindingKind::Abort => "abort",
+        FindingKind::OutOfMemory => "oom",
+        FindingKind::JniError => "jni_error",
+    }
 }
 
 #[cfg(test)]
@@ -270,13 +506,46 @@ mod tests {
         assert_eq!(finding.severity, Severity::Critical);
         assert_eq!(finding.thread.as_deref(), Some("main"));
         assert_eq!(finding.package.as_deref(), Some("com.example.demo"));
+        assert_eq!(finding.occurrence_count, 1);
+        assert!(!finding.signature.is_empty());
         assert!(
             finding
-                .exception
+                .root_cause
                 .as_deref()
                 .unwrap_or_default()
                 .contains("IllegalStateException")
         );
+    }
+
+    #[test]
+    fn deduplicates_repeated_exception_signatures() {
+        let input = r#"03-18 10:15:09.123  2456  2456 E AndroidRuntime: FATAL EXCEPTION: main
+03-18 10:15:09.124  2456  2456 E AndroidRuntime: Process: com.example.demo, PID: 2456
+03-18 10:15:09.125  2456  2456 E AndroidRuntime: java.lang.IllegalStateException: boom 123
+03-18 10:15:09.126  2456  2456 E AndroidRuntime:     at com.example.demo.MainActivity.onCreate(MainActivity.kt:42)
+03-18 10:15:10.123  3456  3456 E AndroidRuntime: FATAL EXCEPTION: main
+03-18 10:15:10.124  3456  3456 E AndroidRuntime: Process: com.example.demo, PID: 3456
+03-18 10:15:10.125  3456  3456 E AndroidRuntime: java.lang.IllegalStateException: boom 999
+03-18 10:15:10.126  3456  3456 E AndroidRuntime:     at com.example.demo.MainActivity.onCreate(MainActivity.kt:108)"#;
+        let report = analyze_text(input);
+
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].occurrence_count, 2);
+    }
+
+    #[test]
+    fn keeps_distinct_root_causes_separate() {
+        let input = r#"03-18 10:15:09.123  2456  2456 E AndroidRuntime: FATAL EXCEPTION: main
+03-18 10:15:09.124  2456  2456 E AndroidRuntime: Process: com.example.demo, PID: 2456
+03-18 10:15:09.125  2456  2456 E AndroidRuntime: java.lang.IllegalStateException: boom
+03-18 10:15:09.126  2456  2456 E AndroidRuntime:     at com.example.demo.MainActivity.onCreate(MainActivity.kt:42)
+03-18 10:16:09.123  2456  2456 E AndroidRuntime: FATAL EXCEPTION: main
+03-18 10:16:09.124  2456  2456 E AndroidRuntime: Process: com.example.demo, PID: 2456
+03-18 10:16:09.125  2456  2456 E AndroidRuntime: java.lang.NullPointerException: missing view
+03-18 10:16:09.126  2456  2456 E AndroidRuntime:     at com.example.demo.DetailsActivity.bind(DetailsActivity.kt:84)"#;
+        let report = analyze_text(input);
+
+        assert_eq!(report.findings.len(), 2);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,12 @@
 mod analyzer;
 mod model;
 mod parser;
+mod report;
 
-pub use model::{AnalysisReport, EvidenceLine, Finding, FindingKind, ParseWarning, Severity};
+pub use model::{
+    AnalysisReport, EvidenceLine, Finding, FindingKind, ParseWarning, ReportSummary, Severity,
+};
+pub use report::{OutputFormat, render_report};
 
 pub fn analyze_text(input: &str) -> AnalysisReport {
     let parsed = parser::parse_lines(input);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,14 @@ use std::fs;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
-use android_log_analyzer::analyze_text;
-use clap::Parser;
+use android_log_analyzer::{OutputFormat, analyze_text, render_report};
+use clap::{Parser, ValueEnum};
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Format {
+    Text,
+    Json,
+}
 
 #[derive(Debug, Parser)]
 #[command(name = "android-log-analyzer")]
@@ -11,14 +17,24 @@ use clap::Parser;
 struct Cli {
     #[arg(value_name = "LOG_FILE")]
     input: Option<PathBuf>,
+
+    #[arg(long, value_enum, default_value_t = Format::Text)]
+    format: Format,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     let input = read_input(cli.input)?;
     let report = analyze_text(&input);
+    let rendered = render_report(
+        &report,
+        match cli.format {
+            Format::Text => OutputFormat::Text,
+            Format::Json => OutputFormat::Json,
+        },
+    )?;
 
-    println!("{report}");
+    println!("{rendered}");
     Ok(())
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -50,6 +48,9 @@ pub struct Finding {
     pub process: Option<String>,
     pub thread: Option<String>,
     pub exception: Option<String>,
+    pub root_cause: Option<String>,
+    pub signature: String,
+    pub occurrence_count: usize,
     pub evidence: Vec<EvidenceLine>,
 }
 
@@ -72,58 +73,16 @@ pub enum Severity {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct AnalysisReport {
-    pub findings: Vec<Finding>,
-    pub parse_warnings: Vec<ParseWarning>,
+pub struct ReportSummary {
+    pub total_findings: usize,
+    pub parse_warning_count: usize,
+    pub top_severity: Option<Severity>,
+    pub root_cause_candidates: Vec<String>,
 }
 
-impl fmt::Display for AnalysisReport {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.findings.is_empty() {
-            writeln!(f, "No high-confidence crash findings detected.")?;
-        } else {
-            writeln!(f, "Likely crash findings: {}", self.findings.len())?;
-
-            for (index, finding) in self.findings.iter().enumerate() {
-                writeln!(
-                    f,
-                    "\n{}. [{:?}] {:?} at lines {}-{}",
-                    index + 1,
-                    finding.severity,
-                    finding.kind,
-                    finding.line_start,
-                    finding.line_end
-                )?;
-                writeln!(f, "   Title: {}", finding.title)?;
-                writeln!(f, "   Why: {}", finding.rationale)?;
-
-                if let Some(process) = &finding.process {
-                    writeln!(f, "   Process: {process}")?;
-                }
-
-                if let Some(thread) = &finding.thread {
-                    writeln!(f, "   Thread: {thread}")?;
-                }
-
-                if let Some(exception) = &finding.exception {
-                    writeln!(f, "   Exception: {exception}")?;
-                }
-
-                writeln!(f, "   Evidence:")?;
-                for evidence in &finding.evidence {
-                    writeln!(f, "     L{} {}", evidence.line_number, evidence.message)?;
-                }
-            }
-        }
-
-        if !self.parse_warnings.is_empty() {
-            writeln!(
-                f,
-                "\nParse warnings: {} line(s) did not match a structured logcat format.",
-                self.parse_warnings.len()
-            )?;
-        }
-
-        Ok(())
-    }
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AnalysisReport {
+    pub summary: ReportSummary,
+    pub findings: Vec<Finding>,
+    pub parse_warnings: Vec<ParseWarning>,
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,101 @@
+use crate::model::{AnalysisReport, Finding};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    Text,
+    Json,
+}
+
+pub fn render_report(
+    report: &AnalysisReport,
+    format: OutputFormat,
+) -> Result<String, serde_json::Error> {
+    match format {
+        OutputFormat::Text => Ok(render_text(report)),
+        OutputFormat::Json => serde_json::to_string_pretty(report),
+    }
+}
+
+fn render_text(report: &AnalysisReport) -> String {
+    let mut output = String::new();
+
+    if report.findings.is_empty() {
+        output.push_str("No high-confidence crash findings detected.\n");
+    } else {
+        output.push_str("Summary\n");
+        output.push_str(&format!("Findings: {}\n", report.summary.total_findings));
+        output.push_str(&format!(
+            "Top severity: {}\n",
+            report
+                .summary
+                .top_severity
+                .map(severity_label)
+                .unwrap_or("unknown")
+        ));
+
+        if !report.summary.root_cause_candidates.is_empty() {
+            output.push_str("Likely root causes:\n");
+            for candidate in &report.summary.root_cause_candidates {
+                output.push_str(&format!("- {candidate}\n"));
+            }
+        }
+
+        output.push_str("\nFindings\n");
+        for (index, finding) in report.findings.iter().enumerate() {
+            write_finding(&mut output, index, finding);
+        }
+    }
+
+    if !report.parse_warnings.is_empty() {
+        output.push_str(&format!(
+            "\nParse warnings: {} line(s) did not match a structured logcat format.\n",
+            report.parse_warnings.len()
+        ));
+    }
+
+    output
+}
+
+fn write_finding(output: &mut String, index: usize, finding: &Finding) {
+    output.push_str(&format!(
+        "\n{}. [{}] {:?} at lines {}-{}\n",
+        index + 1,
+        severity_label(finding.severity),
+        finding.kind,
+        finding.line_start,
+        finding.line_end
+    ));
+    output.push_str(&format!("   Title: {}\n", finding.title));
+    output.push_str(&format!("   Why: {}\n", finding.rationale));
+    output.push_str(&format!("   Signature: {}\n", finding.signature));
+    output.push_str(&format!("   Occurrences: {}\n", finding.occurrence_count));
+
+    if let Some(process) = &finding.process {
+        output.push_str(&format!("   Process: {process}\n"));
+    }
+
+    if let Some(thread) = &finding.thread {
+        output.push_str(&format!("   Thread: {thread}\n"));
+    }
+
+    if let Some(root_cause) = &finding.root_cause {
+        output.push_str(&format!("   Root cause: {root_cause}\n"));
+    }
+
+    output.push_str("   Evidence:\n");
+    for evidence in &finding.evidence {
+        output.push_str(&format!(
+            "     L{} {}\n",
+            evidence.line_number, evidence.message
+        ));
+    }
+}
+
+fn severity_label(severity: crate::model::Severity) -> &'static str {
+    match severity {
+        crate::model::Severity::Low => "low",
+        crate::model::Severity::Medium => "medium",
+        crate::model::Severity::High => "high",
+        crate::model::Severity::Critical => "critical",
+    }
+}

--- a/tests/fixtures/distinct_fatal_exceptions.log
+++ b/tests/fixtures/distinct_fatal_exceptions.log
@@ -1,0 +1,8 @@
+03-18 10:15:09.123  2456  2456 E AndroidRuntime: FATAL EXCEPTION: main
+03-18 10:15:09.124  2456  2456 E AndroidRuntime: Process: com.example.demo, PID: 2456
+03-18 10:15:09.125  2456  2456 E AndroidRuntime: java.lang.IllegalStateException: orderId=123 missing
+03-18 10:15:09.126  2456  2456 E AndroidRuntime:     at com.example.demo.MainActivity.onCreate(MainActivity.kt:42)
+03-18 10:16:09.123  2456  2456 E AndroidRuntime: FATAL EXCEPTION: main
+03-18 10:16:09.124  2456  2456 E AndroidRuntime: Process: com.example.demo, PID: 2456
+03-18 10:16:09.125  2456  2456 E AndroidRuntime: java.lang.NullPointerException: adapter was null
+03-18 10:16:09.126  2456  2456 E AndroidRuntime:     at com.example.demo.DetailsActivity.bind(DetailsActivity.kt:84)

--- a/tests/fixtures/repeated_fatal_exception.log
+++ b/tests/fixtures/repeated_fatal_exception.log
@@ -1,0 +1,8 @@
+03-18 10:15:09.123  2456  2456 E AndroidRuntime: FATAL EXCEPTION: main
+03-18 10:15:09.124  2456  2456 E AndroidRuntime: Process: com.example.demo, PID: 2456
+03-18 10:15:09.125  2456  2456 E AndroidRuntime: java.lang.IllegalStateException: orderId=123 missing
+03-18 10:15:09.126  2456  2456 E AndroidRuntime:     at com.example.demo.MainActivity.onCreate(MainActivity.kt:42)
+03-18 10:15:10.123  3456  3456 E AndroidRuntime: FATAL EXCEPTION: main
+03-18 10:15:10.124  3456  3456 E AndroidRuntime: Process: com.example.demo, PID: 3456
+03-18 10:15:10.125  3456  3456 E AndroidRuntime: java.lang.IllegalStateException: orderId=999 missing
+03-18 10:15:10.126  3456  3456 E AndroidRuntime:     at com.example.demo.MainActivity.onCreate(MainActivity.kt:108)

--- a/tests/report_rendering.rs
+++ b/tests/report_rendering.rs
@@ -1,0 +1,31 @@
+use std::fs;
+use std::path::Path;
+
+use android_log_analyzer::{OutputFormat, analyze_text, render_report};
+
+fn fixture(name: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name);
+    fs::read_to_string(path).expect("fixture to load")
+}
+
+#[test]
+fn json_output_includes_summary_and_occurrence_count() {
+    let report = analyze_text(&fixture("repeated_fatal_exception.log"));
+    let json = render_report(&report, OutputFormat::Json).expect("json render");
+
+    assert!(json.contains("\"summary\""));
+    assert!(json.contains("\"occurrence_count\": 2"));
+}
+
+#[test]
+fn text_output_mentions_occurrences_and_root_cause() {
+    let report = analyze_text(&fixture("repeated_fatal_exception.log"));
+    let text = render_report(&report, OutputFormat::Text).expect("text render");
+
+    assert!(text.contains("Occurrences: 2"));
+    assert!(text.contains("Root cause:"));
+    assert!(text.contains("Likely root causes:"));
+}


### PR DESCRIPTION
## Summary

- closes #3
- adds normalized signatures and conservative deduplication for repeated crash chains
- adds summary-oriented text output and JSON output
- adds tests for repeated incidents, distinct root causes, and report rendering

## Testing

- `CARGO_HOME=/tmp/android-log-analyzer-cargo cargo test --all-targets --all-features`
- `CARGO_HOME=/tmp/android-log-analyzer-cargo cargo clippy --all-targets --all-features -- -D warnings`

## Acceptance Notes

- Covers deduplication, severity ordering, and stable text/json report rendering
- Broader fixture corpus and README/help updates remain for the next issue
